### PR TITLE
Change palette container to circles and add text shadow to page title

### DIFF
--- a/src/containers/App/App.css
+++ b/src/containers/App/App.css
@@ -22,14 +22,12 @@
 .main-header {
   color: #2d9fcc;
   font-family: 'Rock Salt', cursive;
-  /* font-family: 'Permanent Marker', cursive; */
   font-size: 3em;
   margin: 10px 40px;
+  text-shadow: 4px 4px #d84b64;
 }
 
 .user-projects {
   display: flex;
   flex-direction: column;
-  /* grid-gap: 20px 15px; */
-  /* grid-template-columns: repeat(auto-fit, minmax(120px, 0.3fr)); */
 }

--- a/src/containers/PaletteColorItem/PaletteColorItem.css
+++ b/src/containers/PaletteColorItem/PaletteColorItem.css
@@ -1,15 +1,16 @@
 .color-container {
+  border-radius: 50%;
   margin: 15px;
   text-align: center;
-  width: 8%;
-  height: 90%; 
 }
 
 .color-code {
   font-size: 1.5em;
+  margin: 65px 20px 0px 20px;
 }
 
 img {
   width: 25%;
+  margin: 10px auto;
   /* position: relative; */
 }

--- a/src/containers/PaletteContainer/PaletteContainer.css
+++ b/src/containers/PaletteContainer/PaletteContainer.css
@@ -1,6 +1,5 @@
 .palette-container {
   display: flex;
   height: 300px;
-  /* padding: 30px; */
   justify-content: center;
 }


### PR DESCRIPTION
#### What's this PR do?

Updates the styling to change the palette to be circles rather than rectangles and adds text shadow to the header.

#### Where should the reviewer start?

Only file changes were in CSS files

#### How should this be manually tested?

Open up the React App to ensure there's nothing amiss with the styles or positioning.

#### Any background context you want to provide?

Unfortunately I couldn't get the text and image in the circles to center themselves easily, so I had to hard code in some margins. If you can think of an alternative, that's awesome.

#### Screenshots (if appropriate)

<img width="1423" alt="Screen Shot 2019-12-09 at 2 40 58 PM" src="https://user-images.githubusercontent.com/46407593/70475710-59a8bf00-1a92-11ea-8b68-269da9832a1f.png">


